### PR TITLE
fix resend replyTo field

### DIFF
--- a/lib/email-resend.ts
+++ b/lib/email-resend.ts
@@ -38,7 +38,7 @@ async function sendViaResend({
       subject,
       html,
       text: text || html.replace(/<[^>]*>/g, ''),
-      reply_to: replyTo,
+      replyTo,
     });
 
     console.log(`[EMAIL] Resend送信成功: ${result.data?.id}`);


### PR DESCRIPTION
## Summary
- fix resend `replyTo` field name so TypeScript build succeeds

## Testing
- `npm test` (fails: Cannot find module '../../pages/api/posts/index'; Missing API key for Resend)
- `npm run build` (fails: Failed to fetch Roboto from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68a0a8fd0738832fbc13dedd892bef35